### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.9.0"
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "sanitize-html": "^2.15.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,md}": "prettier --write"

--- a/src/utils/content-cleaner.ts
+++ b/src/utils/content-cleaner.ts
@@ -1,3 +1,5 @@
+import sanitizeHtml from 'sanitize-html';
+
 /**
  * Utilities for cleaning and transforming Confluence content
  */
@@ -77,7 +79,7 @@ export function storageFormatToMarkdown(storageFormat: string): string {
   markdown = markdown.replace(/<li[^>]*>(.*?)<\/li>/g, '- $1\n');
 
   // Remove remaining HTML tags
-  markdown = markdown.replace(/<[^>]*>/g, '');
+  markdown = sanitizeHtml(markdown, { allowedTags: [], allowedAttributes: {} });
 
   // Fix spacing
   markdown = markdown.replace(/\n\s*\n/g, '\n\n');


### PR DESCRIPTION
Potential fix for [https://github.com/cosmix/confluence-mcp/security/code-scanning/7](https://github.com/cosmix/confluence-mcp/security/code-scanning/7)

To fix the problem, we need to ensure that all HTML tags, including potentially harmful ones like `<script>`, are completely removed from the input. One effective way to achieve this is to use a well-tested sanitization library, such as `sanitize-html`, which is designed to handle various edge cases and ensure comprehensive sanitization.

The best way to fix the problem without changing existing functionality is to replace the current regular expression-based sanitization with the `sanitize-html` library. This library will provide a more robust and secure way to remove HTML tags and sanitize the input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
