### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for Confluence, enabling AI assistants to interact with Confluence content through a standardized interface.
 
+<a href="https://glama.ai/mcp/servers/@cosmix/confluence-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cosmix/confluence-mcp/badge" alt="Confluence MCP server" />
+</a>
+
 ℹ️ There is a separate MCP server [for Jira](https://github.com/cosmix/jira-mcp)
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [Confluence MCP](https://glama.ai/mcp/servers/@cosmix/confluence-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cosmix/confluence-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cosmix/confluence-mcp/badge" alt="Confluence MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.